### PR TITLE
Upgrade goa to support rails 5.1

### DIFF
--- a/lib/goa/rake_tasks.rb
+++ b/lib/goa/rake_tasks.rb
@@ -47,7 +47,6 @@ class GOA::RakeTasks
         @orig_db_config = Rails.application.config.paths['config/database']
         @orig_schema_format = ActiveRecord::Base.schema_format
         @orig_env_schema = ENV['SCHEMA']
-        @orig_env_structure = ENV['DB_STRUCTURE']
       end
 
       task :setup do
@@ -65,8 +64,8 @@ class GOA::RakeTasks
         end
         ActiveRecord::Base.schema_format = schema_format if schema_format
 
-        ENV['SCHEMA'] = File.join(engine_root, 'db', 'schema.rb')
-        ENV['DB_STRUCTURE'] = File.join(engine_root, 'db', 'structure.sql')
+        schema_file_name = schema_format == :sql ? 'structure.sql' : 'schema.rb'
+        ENV['SCHEMA'] = File.join(engine_root, 'db', schema_file_name)
 
         reset_current_config
         Rake::Task["db:load_config"].execute # load config after we made our changes
@@ -89,7 +88,6 @@ class GOA::RakeTasks
         ActiveRecord::Base.schema_format = @orig_schema_format
 
         ENV['SCHEMA'] = @orig_env_schema
-        ENV['DB_STRUCTURE'] = @orig_env_structure
 
         Rake::Task["db:load_config"].tap { |t| t.execute; t.reenable } # restore original config after done
 

--- a/lib/goa/rake_tasks.rb
+++ b/lib/goa/rake_tasks.rb
@@ -51,7 +51,7 @@ class GOA::RakeTasks
       end
 
       task :setup do
-        %w(db:load_config db:structure:load db:test:purge db:schema:load db:schema:dump db:test:load_structure db:test:clone_structure).each do |name|
+        %w(db:load_config db:structure:load db:schema:load db:schema:dump).each do |name|
           Rake::Task[name].reenable
         end
 

--- a/lib/goa/version.rb
+++ b/lib/goa/version.rb
@@ -1,3 +1,3 @@
 module GOA
-  VERSION = "0.0.6"
+  VERSION = '0.0.7'.freeze
 end


### PR DESCRIPTION
Description: Remove legacy rake tasks for tests that are no longer supported in rails 5.1
Review: @novu/yellow 