### PR TITLE
NOVU-29484 Load environment before executing db tasks

### DIFF
--- a/lib/goa/rake_tasks.rb
+++ b/lib/goa/rake_tasks.rb
@@ -101,7 +101,7 @@ class GOA::RakeTasks
       desc "Run #{name} for app and model gems"
       task "app:#{name}" => ["#{engine_task_namespace}:#{name}", name]
 
-      task "#{engine_task_namespace}:#{name}" => ["#{engine_task_namespace}:startup", "#{engine_task_namespace}:setup"] do
+      task "#{engine_task_namespace}:#{name}" => [:environment, "#{engine_task_namespace}:startup", "#{engine_task_namespace}:setup"] do
         Rake::Task["#{engine_task_namespace}:setup"].reenable
         Rake::Task["#{engine_task_namespace}:teardown"].execute
       end

--- a/lib/goa/version.rb
+++ b/lib/goa/version.rb
@@ -1,3 +1,3 @@
 module GOA
-  VERSION = '0.0.7'.freeze
+  VERSION = '0.0.8'.freeze
 end


### PR DESCRIPTION
[Description](https://mynovu.atlassian.net/browse/NOVU-29484)
Note: The environment configuration `config.active_record.dump_schema_after_migration` is set afterwards the rake novu_core:db:migrate is complete meaning that the database schema will get dump on every environment which is not the right behavior (causing the issue described in JIRA). The fix is requiring the task `:environment` before db:migrate starts.
Review: @varunpanvelkar 